### PR TITLE
restrict availability to iOS 13.0

### DIFF
--- a/Sources/CombineGRPC/Client/BidirectionalStreamingCallPublisher.swift
+++ b/Sources/CombineGRPC/Client/BidirectionalStreamingCallPublisher.swift
@@ -6,7 +6,7 @@ import Combine
 import GRPC
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public struct BidirectionalStreamingCallPublisher<Request, Response>: Publisher
   where Request: Message, Response: Message
 {

--- a/Sources/CombineGRPC/Client/CallPublisherUtils.swift
+++ b/Sources/CombineGRPC/Client/CallPublisherUtils.swift
@@ -5,7 +5,7 @@ import Foundation
 import Combine
 import GRPC
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 func sendCompletion<S>(toSubscriber: S, forStatus: GRPCStatus) -> Void
   where S: Subscriber, S.Failure == GRPCStatus
 {

--- a/Sources/CombineGRPC/Client/Calls.swift
+++ b/Sources/CombineGRPC/Client/Calls.swift
@@ -11,14 +11,14 @@ public typealias UnaryRPC<Request, Response> =
   (Request, CallOptions?) -> UnaryCall<Request, Response>
   where Request: Message, Response: Message
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public typealias ConfiguredUnaryRPC<Request, Response> =
   (@escaping UnaryRPC<Request, Response>)
   -> (Request)
   -> AnyPublisher<Response, GRPCStatus>
   where Request: Message, Response: Message
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func call<Request, Response>(_ rpc: @escaping UnaryRPC<Request, Response>)
   -> (Request)
   -> AnyPublisher<Response, GRPCStatus>
@@ -29,7 +29,7 @@ public func call<Request, Response>(_ rpc: @escaping UnaryRPC<Request, Response>
   }
 }
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func call<Request, Response>(_ callOptions: CallOptions)
   -> (@escaping UnaryRPC<Request, Response>)
   -> (Request)
@@ -49,14 +49,14 @@ public typealias ServerStreamingRPC<Request, Response> =
   (Request, CallOptions?, @escaping (Response) -> Void) -> ServerStreamingCall<Request, Response>
   where Request: Message, Response: Message
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public typealias ConfiguredServerStreamingRPC<Request, Response> =
   (@escaping ServerStreamingRPC<Request, Response>)
   -> (Request)
   -> AnyPublisher<Response, GRPCStatus>
   where Request: Message, Response: Message
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func call<Request, Response>(_ rpc: @escaping ServerStreamingRPC<Request, Response>)
   -> (Request)
   -> AnyPublisher<Response, GRPCStatus>
@@ -69,7 +69,7 @@ public func call<Request, Response>(_ rpc: @escaping ServerStreamingRPC<Request,
   }
 }
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func call<Request, Response>(_ callOptions: CallOptions)
   -> (@escaping ServerStreamingRPC<Request, Response>)
   -> (Request)
@@ -91,14 +91,14 @@ public typealias ClientStreamingRPC<Request, Response> =
   (CallOptions?) -> ClientStreamingCall<Request, Response>
   where Request: Message, Response: Message
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public typealias ConfiguredClientStreamingRPC<Request, Response> =
   (@escaping ClientStreamingRPC<Request, Response>)
   -> (AnyPublisher<Request, Error>)
   -> AnyPublisher<Response, GRPCStatus>
   where Request: Message, Response: Message
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func call<Request, Response>(_ rpc: @escaping ClientStreamingRPC<Request, Response>)
   -> (AnyPublisher<Request, Error>)
   -> AnyPublisher<Response, GRPCStatus>
@@ -110,7 +110,7 @@ public func call<Request, Response>(_ rpc: @escaping ClientStreamingRPC<Request,
   }
 }
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func call<Request, Response>(_ callOptions: CallOptions)
   -> (@escaping ClientStreamingRPC<Request, Response>)
   -> (AnyPublisher<Request, Error>)
@@ -127,12 +127,12 @@ public func call<Request, Response>(_ callOptions: CallOptions)
 
 // MARK: Bidirectional Streaming
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public typealias BidirectionalStreamingRPC<Request, Response> =
   (CallOptions?, @escaping (Response) -> Void) -> BidirectionalStreamingCall<Request, Response>
   where Request: Message, Response: Message
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public typealias ConfiguredBidirectionalStreamingRPC<Request, Response> =
   (@escaping BidirectionalStreamingRPC<Request, Response>)
   -> (AnyPublisher<Request, Error>)
@@ -153,7 +153,7 @@ public func call<Request, Response>(_ rpc: @escaping BidirectionalStreamingRPC<R
   }
 }
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func call<Request, Response>(_ callOptions: CallOptions)
   -> (@escaping BidirectionalStreamingRPC<Request, Response>)
   -> (AnyPublisher<Request, Error>)

--- a/Sources/CombineGRPC/Client/ClientStreamingCallPublisher.swift
+++ b/Sources/CombineGRPC/Client/ClientStreamingCallPublisher.swift
@@ -6,7 +6,7 @@ import Combine
 import GRPC
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public struct ClientStreamingCallPublisher<Request, Response>: Publisher where Request: Message, Response: Message {
   public typealias Output = Response
   public typealias Failure = GRPCStatus

--- a/Sources/CombineGRPC/Client/MessageBridge.swift
+++ b/Sources/CombineGRPC/Client/MessageBridge.swift
@@ -5,7 +5,7 @@ import Foundation
 import Combine
 import GRPC
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 struct MessageBridge<T> {
   let messagePublisher = PassthroughSubject<T, GRPCStatus>()
   

--- a/Sources/CombineGRPC/Client/ServerStreamingCallPublisher.swift
+++ b/Sources/CombineGRPC/Client/ServerStreamingCallPublisher.swift
@@ -6,7 +6,7 @@ import Combine
 import GRPC
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public struct ServerStreamingCallPublisher<Request, Response>: Publisher where Request: Message, Response: Message {
   public typealias Output = Response
   public typealias Failure = GRPCStatus

--- a/Sources/CombineGRPC/Client/UnaryCallPublisher.swift
+++ b/Sources/CombineGRPC/Client/UnaryCallPublisher.swift
@@ -6,7 +6,7 @@ import Combine
 import GRPC
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public struct UnaryCallPublisher<Request, Response>: Publisher where Request: Message, Response: Message {
   public typealias Output = Response
   public typealias Failure = GRPCStatus

--- a/Sources/CombineGRPC/Server/BidirectionalStreamingHandlerSubscriber.swift
+++ b/Sources/CombineGRPC/Server/BidirectionalStreamingHandlerSubscriber.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class BidirectionalStreamingHandlerSubscriber<Request, Response>: Subscriber, Cancellable where Response: Message {
   typealias Input = Response
   typealias Failure = GRPCStatus

--- a/Sources/CombineGRPC/Server/ClientStreamingHandlerSubscriber.swift
+++ b/Sources/CombineGRPC/Server/ClientStreamingHandlerSubscriber.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class ClientStreamingHandlerSubscriber<Request, Response>: Subscriber, Cancellable where Request: Message, Response: Message {
   typealias Input = Response
   typealias Failure = GRPCStatus

--- a/Sources/CombineGRPC/Server/Handlers.swift
+++ b/Sources/CombineGRPC/Server/Handlers.swift
@@ -8,7 +8,7 @@ import SwiftProtobuf
 
 // MARK: Unary
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func handle<Response>(_ context: StatusOnlyCallContext,
                              handler: () -> AnyPublisher<Response, GRPCStatus>) -> EventLoopFuture<Response>
 {
@@ -17,7 +17,7 @@ public func handle<Response>(_ context: StatusOnlyCallContext,
   return unarySubscriber.futureResult
 }
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func handle<Request, Response>(_ request: Request, _ context: StatusOnlyCallContext,
                                       handler: (Request) -> AnyPublisher<Response, GRPCStatus>)
                                      -> EventLoopFuture<Response>
@@ -29,7 +29,7 @@ public func handle<Request, Response>(_ request: Request, _ context: StatusOnlyC
 
 // MARK: Server Streaming
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func handle<Response>(_ context: StreamingResponseCallContext<Response>,
                              handler: () -> AnyPublisher<Response, GRPCStatus>) -> EventLoopFuture<GRPCStatus>
 {
@@ -38,7 +38,7 @@ public func handle<Response>(_ context: StreamingResponseCallContext<Response>,
   return serverStreamingSubscriber.futureStatus
 }
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func handle<Request, Response>(_ request: Request, _ context: StreamingResponseCallContext<Response>,
                                       handler: (Request) -> AnyPublisher<Response, GRPCStatus>)
                                      -> EventLoopFuture<GRPCStatus>
@@ -50,7 +50,7 @@ public func handle<Request, Response>(_ request: Request, _ context: StreamingRe
 
 // MARK: Client Streaming
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func handle<Request, Response>(_ context: UnaryResponseCallContext<Response>,
                                       handler: (AnyPublisher<Request, Never>) -> AnyPublisher<Response, GRPCStatus>)
                                      -> EventLoopFuture<(StreamEvent<Request>) -> Void>
@@ -69,7 +69,7 @@ public func handle<Request, Response>(_ context: UnaryResponseCallContext<Respon
 
 // MARK: Bidirectional Streaming
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 public func handle<Request, Response>(_ context: StreamingResponseCallContext<Response>,
                                       handler: (AnyPublisher<Request, Never>) -> AnyPublisher<Response, GRPCStatus>)
                                      -> EventLoopFuture<(StreamEvent<Request>) -> Void>

--- a/Sources/CombineGRPC/Server/ServerStreamingHandlerSubscriber.swift
+++ b/Sources/CombineGRPC/Server/ServerStreamingHandlerSubscriber.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class ServerStreamingHandlerSubscriber<Response>: Subscriber, Cancellable where Response: Message {
   typealias Input = Response
   typealias Failure = GRPCStatus

--- a/Sources/CombineGRPC/Server/UnaryHandlerSubscriber.swift
+++ b/Sources/CombineGRPC/Server/UnaryHandlerSubscriber.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 import SwiftProtobuf
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class UnaryHandlerSubscriber<Response>: Subscriber, Cancellable {
   typealias Input = Response
   typealias Failure = GRPCStatus

--- a/Tests/CombineGRPCTests/BidirectionalStreamingTests.swift
+++ b/Tests/CombineGRPCTests/BidirectionalStreamingTests.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 @testable import CombineGRPC
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class BidirectionalStreamingTests: XCTestCase {
   
   static var serverEventLoopGroup: EventLoopGroup?

--- a/Tests/CombineGRPCTests/ClientStreamingTests.swift
+++ b/Tests/CombineGRPCTests/ClientStreamingTests.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 @testable import CombineGRPC
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class ClientStreamingTests: XCTestCase {
   
   static var serverEventLoopGroup: EventLoopGroup?

--- a/Tests/CombineGRPCTests/ServerStreamingTests.swift
+++ b/Tests/CombineGRPCTests/ServerStreamingTests.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 @testable import CombineGRPC
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class ServerStreamingTests: XCTestCase {
   
   static var serverEventLoopGroup: EventLoopGroup?

--- a/Tests/CombineGRPCTests/StressTest.swift
+++ b/Tests/CombineGRPCTests/StressTest.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 @testable import CombineGRPC
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 class StressTest: XCTestCase {
 
   static var serverEventLoopGroup: EventLoopGroup?

--- a/Tests/CombineGRPCTests/UnaryTests.swift
+++ b/Tests/CombineGRPCTests/UnaryTests.swift
@@ -7,7 +7,7 @@ import GRPC
 import NIO
 @testable import CombineGRPC
 
-@available(OSX 10.15, *)
+@available(OSX 10.15, iOS 13.0, *)
 final class UnaryTests: XCTestCase {
   
   static var serverEventLoopGroup: EventLoopGroup?


### PR DESCRIPTION
Pretty self explanatory, `@available(OSX 10.15, *)` -> `@available(OSX 10.15, iOS 13.0, *)`.
Otherwise it wouldn't work with iOS.