### PR TITLE
Ensure server handler subscribers operate on event loop

### DIFF
--- a/Sources/CombineGRPC/Server/BidirectionalStreamingHandlerSubscriber.swift
+++ b/Sources/CombineGRPC/Server/BidirectionalStreamingHandlerSubscriber.swift
@@ -32,8 +32,15 @@ class BidirectionalStreamingHandlerSubscriber<Request, Response>: Subscriber, Ca
   func receive(completion: Subscribers.Completion<RPCError>) {
     switch completion {
     case .failure(let error):
-      context.trailers = augment(headers: context.trailers, with: error)
-      context.statusPromise.fail(error.status)
+      if context.eventLoop.inEventLoop {
+        context.trailers = augment(headers: context.trailers, with: error)
+        context.statusPromise.fail(error.status)
+      } else {
+        context.eventLoop.execute {
+          self.context.trailers = augment(headers: self.context.trailers, with: error)
+          self.context.statusPromise.fail(error.status)
+        }
+      }
     case .finished:
       context.statusPromise.succeed(.ok)
     }


### PR DESCRIPTION
The ensures that `context.trailers` is called on the event loop.

Without this, `subscribe(on:)` and `receive(on:)` in client code causes precondition failures; `context.trailers` must be updated only on the event loop thread.